### PR TITLE
Add Github Actions Workflow to Run `unittest` and Generate Coverage Badge

### DIFF
--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -1,0 +1,44 @@
+# Syntax reference for this file:
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+
+name: test-and-coverage
+on: [push]
+
+# https://gist.github.com/c-bata/ed5e7b7f8015502ee5092a3e77937c99
+jobs:
+  test-and-cover:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/marketplace/actions/checkout
+      - uses: actions/checkout@v2
+      # https://github.com/marketplace/actions/setup-python
+      # ^-- This gives info on matrix testing.
+      - name: Install Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: "3.10"
+      # I don't know where the "run" thing is documented.
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install coverage coverage-badge
+          pip install .
+      - name: Run unittest and Generate Coverage Badge
+        if: success()
+        run: |
+          coverage run --source=./bitbucketserver -m unittest discover .
+          coverage-badge -o output/coverage.svg
+
+      # https://github.com/peaceiris/actions-gh-pages
+      - name: Deploy
+        if: success()
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          publish_branch: coverage-badge
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: output/
+
+
+# This action probably does everything for you:
+# https://github.com/marketplace/actions/sphinx-build

--- a/.github/workflows/test-and-coverage.yml
+++ b/.github/workflows/test-and-coverage.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Run unittest and Generate Coverage Badge
         if: success()
         run: |
+          mkdir output
           coverage run --source=./bitbucketserver -m unittest discover .
           coverage-badge -o output/coverage.svg
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ build/
 dist/
 .coverage
 *.egg-info/
+
+# Ignore Pycache
+*/__pycache__/

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # Bitbucket Server API Wrapper
 A simple wrapper for the Atlassian's Bitbucket Server / Bitbucket Datacenter (formerly Stash) REST API, written in Python.
 
-[![Test](https://github.com/JoeStanleySEL/bitbucketserver/actions/workflows/test-and-coverage.yml/badge.svg?branch=master)](https://github.com/JoeStanleySEL/bitbucketserver/actions/workflows/test-and-coverage.yml)
-![Coverage](https://raw.githubusercontent.com/JoeStanleySEL/bitbucketserver/coverage-badge/coverage.svg)
+[![Test](https://github.com/Schweitzer-Engineering-Laboratories/bitbucketserver/actions/workflows/test-and-coverage.yml/badge.svg?branch=master)](https://github.com/Schweitzer-Engineering-Laboratories/bitbucketserver/actions/workflows/test-and-coverage.yml)
+![Coverage](https://raw.githubusercontent.com/Schweitzer-Engineering-Laboratories/bitbucketserver/coverage-badge/coverage.svg)
 
 ## Usage
 

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # Bitbucket Server API Wrapper
 A simple wrapper for the Atlassian's Bitbucket Server / Bitbucket Datacenter (formerly Stash) REST API, written in Python.
 
-[![Test](https://github.com/JoeStanleySEL/bitbucketserver/actions/workflows/test-and-cover.yml/badge.svg?branch=master)](https://github.com/JoeStanleySEL/bitbucketserver/actions/workflows/test-and-cover.yml)
+[![Test](https://github.com/JoeStanleySEL/bitbucketserver/actions/workflows/test-and-coverage.yml/badge.svg?branch=master)](https://github.com/JoeStanleySEL/bitbucketserver/actions/workflows/test-and-coverage.yml)
 ![Coverage](https://raw.githubusercontent.com/JoeStanleySEL/bitbucketserver/coverage-badge/coverage.svg)
 
 ## Usage

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,9 @@
 # Bitbucket Server API Wrapper
 A simple wrapper for the Atlassian's Bitbucket Server / Bitbucket Datacenter (formerly Stash) REST API, written in Python.
 
+[![Test](https://github.com/JoeStanleySEL/bitbucketserver/actions/workflows/test-and-cover.yml/badge.svg?branch=master)](https://github.com/bitbucketserver/actions/workflows/test-and-cover.yml)
+![Coverage](https://raw.githubusercontent.com/JoeStanleySEL/bitbucketserver/coverage-badge/coverage.svg)
+
 ## Usage
 
 ### Instantiating
@@ -59,3 +62,16 @@ This module uses the Python library [Requests](http://docs.python-requests.org/e
     pip install requests
 
 Version 2.4.2 or greater is required.
+
+
+## Development
+
+### Testing
+Tests are written using Python `unittest` and can be executed with the following command:
+
+    python3 -m unittest discover .
+
+To observe test-coverage, you may use the [`coverage.py`](https://coverage.readthedocs.io/en/latest/) tool with the following
+command:
+
+    python3 -m coverage --source ./bitbucketserver -m unittest discover .

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 # Bitbucket Server API Wrapper
 A simple wrapper for the Atlassian's Bitbucket Server / Bitbucket Datacenter (formerly Stash) REST API, written in Python.
 
-[![Test](https://github.com/JoeStanleySEL/bitbucketserver/actions/workflows/test-and-cover.yml/badge.svg?branch=master)](https://github.com/bitbucketserver/actions/workflows/test-and-cover.yml)
+[![Test](https://github.com/JoeStanleySEL/bitbucketserver/actions/workflows/test-and-cover.yml/badge.svg?branch=master)](https://github.com/JoeStanleySEL/bitbucketserver/actions/workflows/test-and-cover.yml)
 ![Coverage](https://raw.githubusercontent.com/JoeStanleySEL/bitbucketserver/coverage-badge/coverage.svg)
 
 ## Usage


### PR DESCRIPTION
Not sure how terribly important this is, but I find these sorts of automated workflows to be helpful in terms of general project visibility. This documents the basics of running tests manually, as well as automating the process with a Github action that also generates a code-coverage badge.